### PR TITLE
Removed useNavigate from failed solution attempt 

### DIFF
--- a/client/src/utils/auth.ts
+++ b/client/src/utils/auth.ts
@@ -1,6 +1,4 @@
 import { JwtPayload, jwtDecode } from 'jwt-decode';
-// trying this to fix render issue...
-import { useNavigate } from 'react-router-dom'
 //added for the get profile function
 import type { UserData } from '../interfaces/UserData';
 class AuthService {


### PR DESCRIPTION
- For best results, do not call useNavigate in a class. React will not thank you for that.
- Additionally, don't leave said navigate function available and not comment or delete it because Typescript will not thank you for that either.